### PR TITLE
Fixed permission issues with prometheus/grafana and timeout errors in nginx

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,6 +92,7 @@ services:
       - backend
       - backend1
       - loadbalancer
+    user: root
 
   grafana:
     image: grafana/grafana:latest
@@ -107,3 +108,4 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
     ports:
       - "9091:3000"
+    user: "0"

--- a/nginx_edge.conf
+++ b/nginx_edge.conf
@@ -32,6 +32,7 @@ http {
         edge.simulate_load()
       }
 
+      proxy_read_timeout 3600;
       proxy_pass http://backend;
       include generic_conf/define_cache.conf;
       add_header X-Edge Server;

--- a/nginx_loadbalancer.conf
+++ b/nginx_loadbalancer.conf
@@ -34,8 +34,9 @@ http {
         loadbalancer.resolve_name_for_upstream()
       }
 
+      proxy_read_timeout 3600;
       proxy_pass http://backend;
-      add_header X-Edge LoadBalancer;
+      add_header X-Edge LoadBaalancer;
     }
 
     include generic_conf/basic_vts_location.conf;

--- a/nginx_loadbalancer.conf
+++ b/nginx_loadbalancer.conf
@@ -36,7 +36,7 @@ http {
 
       proxy_read_timeout 3600;
       proxy_pass http://backend;
-      add_header X-Edge LoadBaalancer;
+      add_header X-Edge LoadBalancer;
     }
 
     include generic_conf/basic_vts_location.conf;


### PR DESCRIPTION
Adjusted permissions to ensure Prometheus and Grafana can access all necessary files for proper functionality.

Sometimes upstream takes too long to answer the request and NGINX thinks the upstream already failed in processing the request, so it responds with an error.  Adjusted proxy_read_timeout to avoid that.